### PR TITLE
Add JSDoc documentation to the catsservice

### DIFF
--- a/src/data-access/cats-data.ts
+++ b/src/data-access/cats-data.ts
@@ -2,6 +2,12 @@ import { Array, Context, Effect, HashMap, Layer, Ref } from "effect";
 import { Cat, CatId } from "../domain/cats";
 import { CatNotFoundError } from "../domain/errors";
 
+/**
+ * Interface for a collection of operations to access and persist cats.
+ * It is implemented by `makeCatsData`.
+ *
+ * @see makeCatsData
+ */
 export class CatsData extends Context.Tag("CatsData")<
   CatsData,
   {
@@ -15,6 +21,11 @@ export class CatsData extends Context.Tag("CatsData")<
 export const makeCatsData = Effect.gen(function* () {
   const catsState = yield* Ref.make(HashMap.empty<CatId, Cat>());
 
+  /**
+   * Finds a cat by its ID.
+   * @param id The ID of the cat to find.
+   * @returns An Effect that resolves to the Cat if found, or fails with a CatNotFoundError.
+   */
   const findById = (id: string): Effect.Effect<Cat, CatNotFoundError> =>
     Ref.get(catsState).pipe(
       Effect.flatMap(HashMap.get(id as CatId)),
@@ -24,15 +35,30 @@ export const makeCatsData = Effect.gen(function* () {
       ),
     );
 
+  /**
+   * Persists a cat to the data store.
+   * If a cat with the same ID already exists, it will be overwritten.
+   * @param cat The cat to persist.
+   * @returns An Effect that resolves when the cat has been persisted.
+   */
   const persist = (cat: Cat): Effect.Effect<void> =>
     Ref.update(catsState, HashMap.set(cat.id, cat));
 
+  /**
+   * Retrieves all cats from the data store.
+   * @returns An Effect that resolves to a readonly array of all cats.
+   */
   const findAll = (): Effect.Effect<ReadonlyArray<Cat>> =>
     Ref.get(catsState).pipe(
       Effect.map(HashMap.values),
       Effect.map(Array.fromIterable),
     );
 
+  /**
+   * Removes a cat from the data store by its ID.
+   * @param id The ID of the cat to remove.
+   * @returns An Effect that resolves if the cat is successfully removed, or fails with a CatNotFoundError if the cat is not found.
+   */
   const removeById = (id: string): Effect.Effect<void, CatNotFoundError> =>
     Ref.get(catsState).pipe(
       Effect.flatMap((catsMap) =>

--- a/src/domain/cats.ts
+++ b/src/domain/cats.ts
@@ -2,12 +2,34 @@ import { Schema } from "effect";
 
 const PositiveInt = Schema.Int.pipe(Schema.positive());
 
+/**
+ * @brand CatId
+ * A branded type for Cat IDs.
+ * This helps ensure that we don't accidentally use a regular string where a CatId is expected.
+ */
 export const CatId = Schema.String.pipe(Schema.brand("CatId"));
 export type CatId = typeof CatId.Type;
 
+/**
+ * Represents a cat with its properties.
+ */
 export class Cat extends Schema.Class<Cat>("Cat")({
+  /**
+   * The unique identifier for the cat.
+   */
   id: CatId,
+  /**
+   * The name of the cat.
+   */
   name: Schema.String,
+  /**
+   * The age of the cat in years.
+   * Must be a positive integer.
+   */
   age: PositiveInt,
+  /**
+   * The breed of the cat.
+   * Must be one of the specified literal values.
+   */
   breed: Schema.Literal("Abyssinian", "Bombay", "Chartreux"),
 }) {}

--- a/src/services/cats.ts
+++ b/src/services/cats.ts
@@ -3,6 +3,13 @@ import { CatsData } from "../data-access/cats-data";
 import { Cat } from "../domain/cats";
 import { CatNotFoundError } from "../domain/errors";
 
+/**
+ * Represents the main service for managing cat-related operations.
+ * This class defines the interface for the Cats service, which is implemented by `makeCats`.
+ *
+ * @see makeCats
+ * @see CatsLayer
+ */
 export class Cats extends Context.Tag("Cats")<
   Cats,
   {
@@ -16,11 +23,23 @@ export class Cats extends Context.Tag("Cats")<
 export const makeCats = Effect.gen(function* () {
   const catsData = yield* CatsData;
 
+  /**
+   * Finds a cat by its ID using the CatsData service.
+   * Includes logging before and after the data access call.
+   * @param id The ID of the cat to find.
+   * @returns An Effect that resolves to the Cat if found, or fails with a CatNotFoundError.
+   */
   const findById = Effect.fn("Cats.findById")(function* (id: string) {
     yield* Effect.log(`findById ${id}`).pipe(Effect.annotateLogs({ id }));
     return yield* catsData.findById(id);
   });
 
+  /**
+   * Persists a cat using the CatsData service.
+   * Includes logging before the data access call.
+   * @param cat The cat to persist.
+   * @returns An Effect that resolves to a success message ("Saved") when the cat has been persisted.
+   */
   const persist = Effect.fn("Cats.persist")(function* (cat: Cat) {
     yield* Effect.log(`persist cat ${cat.name}`).pipe(
       Effect.annotateLogs({ catId: cat.id }),
@@ -29,11 +48,22 @@ export const makeCats = Effect.gen(function* () {
     return yield* Effect.succeed("Saved");
   });
 
+  /**
+   * Retrieves all cats using the CatsData service.
+   * Includes logging before the data access call.
+   * @returns An Effect that resolves to a readonly array of all cats.
+   */
   const findAll = Effect.fn("Cats.findAll")(function* () {
     yield* Effect.log("findAll cats");
     return yield* catsData.findAll();
   });
 
+  /**
+   * Removes a cat by its ID using the CatsData service.
+   * Includes logging before the data access call.
+   * @param id The ID of the cat to remove.
+   * @returns An Effect that resolves if the cat is successfully removed, or fails with a CatNotFoundError if the cat is not found.
+   */
   const removeById = Effect.fn("Cats.removeById")(function* (id: string) {
     yield* Effect.log(`removeById ${id}`).pipe(Effect.annotateLogs({ id }));
     return yield* catsData.removeById(id);
@@ -47,4 +77,8 @@ export const makeCats = Effect.gen(function* () {
   } as const; // Using "as const" to keep the types readonly and strict
 });
 
+/**
+ * Provides the implementation for the Cats service.
+ * This layer wires up the `makeCats` constructor, which itself depends on `CatsData`.
+ */
 export const CatsLayer = Layer.effect(Cats, makeCats);


### PR DESCRIPTION
This commit adds JSDoc comments to the following files:
- src/domain/cats.ts: Documented CatId type and Cat class.
- src/data-access/cats-data.ts: Documented CatsData class and its methods.
- src/services/cats.ts: Documented Cats service class, its methods, and CatsLayer.

These changes improve code clarity and maintainability by providing clear explanations of the different components of the catsservice.