### PR TITLE
Here's the rewritten message:

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.0.0-beta.2",
+        "tsx": "^4.19.4",
         "typescript": "^5.8.3"
       }
     },
@@ -294,6 +295,406 @@
         "@effect/experimental": "^0.44.19",
         "@effect/platform": "^0.80.19",
         "effect": "^3.14.19"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.5.tgz",
+      "integrity": "sha512-9o3TMmpmftaCMepOdA5k/yDw8SfInyzWWTjYTFCX3kPSDJMROQTb8jg+h9Cnwnmm1vOzvxN7gIfB5V2ewpjtGA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.5.tgz",
+      "integrity": "sha512-AdJKSPeEHgi7/ZhuIPtcQKr5RQdo6OO2IL87JkianiMYMPbCtot9fxPbrMiBADOWWm3T2si9stAiVsGbTQFkbA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.5.tgz",
+      "integrity": "sha512-VGzGhj4lJO+TVGV1v8ntCZWJktV7SGCs3Pn1GRWI1SBFtRALoomm8k5E9Pmwg3HOAal2VDc2F9+PM/rEY6oIDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.5.tgz",
+      "integrity": "sha512-D2GyJT1kjvO//drbRT3Hib9XPwQeWd9vZoBJn+bu/lVsOZ13cqNdDeqIF/xQ5/VmWvMduP6AmXvylO/PIc2isw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.5.tgz",
+      "integrity": "sha512-GtaBgammVvdF7aPIgH2jxMDdivezgFu6iKpmT+48+F8Hhg5J/sfnDieg0aeG/jfSvkYQU2/pceFPDKlqZzwnfQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.5.tgz",
+      "integrity": "sha512-1iT4FVL0dJ76/q1wd7XDsXrSW+oLoquptvh4CLR4kITDtqi2e/xwXwdCVH8hVHU43wgJdsq7Gxuzcs6Iq/7bxQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.5.tgz",
+      "integrity": "sha512-nk4tGP3JThz4La38Uy/gzyXtpkPW8zSAmoUhK9xKKXdBCzKODMc2adkB2+8om9BDYugz+uGV7sLmpTYzvmz6Sw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.5.tgz",
+      "integrity": "sha512-PrikaNjiXdR2laW6OIjlbeuCPrPaAl0IwPIaRv+SMV8CiM8i2LqVUHFC1+8eORgWyY7yhQY+2U2fA55mBzReaw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.5.tgz",
+      "integrity": "sha512-cPzojwW2okgh7ZlRpcBEtsX7WBuqbLrNXqLU89GxWbNt6uIg78ET82qifUy3W6OVww6ZWobWub5oqZOVtwolfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.5.tgz",
+      "integrity": "sha512-Z9kfb1v6ZlGbWj8EJk9T6czVEjjq2ntSYLY2cw6pAZl4oKtfgQuS4HOq41M/BcoLPzrUbNd+R4BXFyH//nHxVg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.5.tgz",
+      "integrity": "sha512-sQ7l00M8bSv36GLV95BVAdhJ2QsIbCuCjh/uYrWiMQSUuV+LpXwIqhgJDcvMTj+VsQmqAHL2yYaasENvJ7CDKA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.5.tgz",
+      "integrity": "sha512-0ur7ae16hDUC4OL5iEnDb0tZHDxYmuQyhKhsPBV8f99f6Z9KQM02g33f93rNH5A30agMS46u2HP6qTdEt6Q1kg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.5.tgz",
+      "integrity": "sha512-kB/66P1OsHO5zLz0i6X0RxlQ+3cu0mkxS3TKFvkb5lin6uwZ/ttOkP3Z8lfR9mJOBk14ZwZ9182SIIWFGNmqmg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.5.tgz",
+      "integrity": "sha512-UZCmJ7r9X2fe2D6jBmkLBMQetXPXIsZjQJCjgwpVDz+YMcS6oFR27alkgGv3Oqkv07bxdvw7fyB71/olceJhkQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.5.tgz",
+      "integrity": "sha512-kTxwu4mLyeOlsVIFPfQo+fQJAV9mh24xL+y+Bm6ej067sYANjyEw1dNHmvoqxJUCMnkBdKpvOn0Ahql6+4VyeA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.5.tgz",
+      "integrity": "sha512-K2dSKTKfmdh78uJ3NcWFiqyRrimfdinS5ErLSn3vluHNeHVnBAFWC8a4X5N+7FgVE1EjXS1QDZbpqZBjfrqMTQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.5.tgz",
+      "integrity": "sha512-uhj8N2obKTE6pSZ+aMUbqq+1nXxNjZIIjCjGLfsWvVpy7gKCOL6rsY1MhRh9zLtUtAI7vpgLMK6DxjO8Qm9lJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.5.tgz",
+      "integrity": "sha512-pwHtMP9viAy1oHPvgxtOv+OkduK5ugofNTVDilIzBLpoWAM16r7b/mxBvfpuQDpRQFMfuVr5aLcn4yveGvBZvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.5.tgz",
+      "integrity": "sha512-WOb5fKrvVTRMfWFNCroYWWklbnXH0Q5rZppjq0vQIdlsQKuw6mdSihwSo4RV/YdQ5UCKKvBy7/0ZZYLBZKIbwQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.5.tgz",
+      "integrity": "sha512-7A208+uQKgTxHd0G0uqZO8UjK2R0DDb4fDmERtARjSHWxqMTye4Erz4zZafx7Di9Cv+lNHYuncAkiGFySoD+Mw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.5.tgz",
+      "integrity": "sha512-G4hE405ErTWraiZ8UiSoesH8DaCsMm0Cay4fsFWOOUcz8b8rC6uCvnagr+gnioEjWn0wC+o1/TAHt+It+MpIMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.5.tgz",
+      "integrity": "sha512-l+azKShMy7FxzY0Rj4RCt5VD/q8mG/e+mDivgspo+yL8zW7qEwctQ6YqKX34DTEleFAvCIUviCFX1SDZRSyMQA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.5.tgz",
+      "integrity": "sha512-O2S7SNZzdcFG7eFKgvwUEZ2VG9D/sn/eIiz8XRZ1Q/DO5a3s76Xv0mdBzVM5j5R639lXQmPmSo0iRpHqUUrsxw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.5.tgz",
+      "integrity": "sha512-onOJ02pqs9h1iMJ1PQphR+VZv8qBMQ77Klcsqv9CNW2w6yLqoURLcgERAIurY6QE63bbLuqgP9ATqajFLK5AMQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.5.tgz",
+      "integrity": "sha512-TXv6YnJ8ZMVdX+SXWVBo/0p8LTcrUYngpWjvm91TMjjBQii7Oz11Lw5lbDV5Y0TzuhSJHwiH4hEtC1I42mMS0g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
@@ -725,6 +1126,46 @@
         "fast-check": "^3.23.1"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.5.tgz",
+      "integrity": "sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.5",
+        "@esbuild/android-arm": "0.25.5",
+        "@esbuild/android-arm64": "0.25.5",
+        "@esbuild/android-x64": "0.25.5",
+        "@esbuild/darwin-arm64": "0.25.5",
+        "@esbuild/darwin-x64": "0.25.5",
+        "@esbuild/freebsd-arm64": "0.25.5",
+        "@esbuild/freebsd-x64": "0.25.5",
+        "@esbuild/linux-arm": "0.25.5",
+        "@esbuild/linux-arm64": "0.25.5",
+        "@esbuild/linux-ia32": "0.25.5",
+        "@esbuild/linux-loong64": "0.25.5",
+        "@esbuild/linux-mips64el": "0.25.5",
+        "@esbuild/linux-ppc64": "0.25.5",
+        "@esbuild/linux-riscv64": "0.25.5",
+        "@esbuild/linux-s390x": "0.25.5",
+        "@esbuild/linux-x64": "0.25.5",
+        "@esbuild/netbsd-arm64": "0.25.5",
+        "@esbuild/netbsd-x64": "0.25.5",
+        "@esbuild/openbsd-arm64": "0.25.5",
+        "@esbuild/openbsd-x64": "0.25.5",
+        "@esbuild/sunos-x64": "0.25.5",
+        "@esbuild/win32-arm64": "0.25.5",
+        "@esbuild/win32-ia32": "0.25.5",
+        "@esbuild/win32-x64": "0.25.5"
+      }
+    },
     "node_modules/fast-check": {
       "version": "3.23.2",
       "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
@@ -765,6 +1206,32 @@
       "integrity": "sha512-4GOTMrpGQVzsCH2ruUn2vmwzV/02zF4q+ybhCIrw/Rkt3L8KWcycdC6aJMctJzwN4fXD4SD5F/4B9Sksh5rE0A==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
+      "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
+      "dev": true,
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -921,6 +1388,15 @@
       ],
       "license": "MIT"
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -931,6 +1407,25 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.19.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.4.tgz",
+      "integrity": "sha512-gK5GVzDkJK1SI1zwHf32Mqxf2tSJkNx+eYcNly5+nHvWqXUJYUkWBQtKauoESz3ymezAI++ZwT855x5p5eop+Q==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
       }
     },
     "node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "tsx src/index.ts"
   },
   "keywords": [],
   "author": "",
@@ -11,6 +12,7 @@
   "description": "",
   "devDependencies": {
     "@biomejs/biome": "2.0.0-beta.2",
+    "tsx": "^4.19.4",
     "typescript": "^5.8.3"
   },
   "dependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,34 +1,108 @@
 import { DevTools } from "@effect/experimental";
 import { NodeRuntime, NodeSocket } from "@effect/platform-node";
-import { Effect, Layer, pipe } from "effect";
-// import { Cat } from "./domain/cats"; // Cat not directly used here anymore
+import { Effect, Layer, pipe, Schema, Option } from "effect";
+import { Cat, CatId } from "./domain/cats"; // Cat is used for creation
 import { Cats, CatsLayer } from "./services/cats";
 import { CatsDataLayer } from "./data-access/cats-data";
 
+// Import from Veterinary Bounded Context
+import { HealthRecordsService, HealthRecordsServiceLayer } from "./veterinary/services/health-records";
+import { HealthRecordsDataLayer } from "./veterinary/data-access/health-records-data";
+import { HealthRecordEventType } from "./veterinary/domain/health-record"; // Import EventType
+
 const program = Effect.gen(function* () {
   const catsService = yield* Cats;
+  const healthRecordsService = yield* HealthRecordsService;
 
-  // Example: Persist a cat
-  // const newCat = new Cat({ id: "cat1" as CatId, name: "Whiskers", age: 2, breed: "Bombay" });
-  // yield* catsService.persist(newCat);
+  // --- Cats Service Demonstration ---
+  // Create a new cat
+  const newCat = new Cat({
+    id: "cat001" as CatId,
+    name: "Whiskers",
+    age: 3,
+    breed: "Bombay"
+  });
+  yield* catsService.persist(newCat);
+  yield* Effect.logInfo(`Cat ${newCat.name} persisted with ID: ${newCat.id}`);
 
-  // Example: Find a cat
-  const foundCat = yield* catsService.findById("cat1");
-  console.log("Found cat:", foundCat);
+  // Find the cat
+  const foundCat = yield* catsService.findById(newCat.id);
+  yield* Effect.logInfo("Found cat:", foundCat);
 
-  // Example: Find all cats
-  // const allCats = yield* catsService.findAll();
-  // console.log("All cats:", allCats);
+  // --- HealthRecords Service Demonstration ---
+  // Add a health record for the cat
+  const newHealthRecord = yield* healthRecordsService.addRecord({
+    catId: foundCat.id,
+    date: new Date(),
+    eventType: "Checkup" as HealthRecordEventType, // Make sure this matches one of the literals
+    notes: "Annual checkup, all good.",
+    veterinarianName: "Dr. Pawson"
+  });
+  yield* Effect.logInfo("Added health record:", newHealthRecord);
+
+  // Add another health record for the same cat
+  const anotherHealthRecord = yield* healthRecordsService.addRecord({
+    catId: foundCat.id,
+    date: new Date(2023, 10, 15), // Month is 0-indexed
+    eventType: "Vaccination" as HealthRecordEventType,
+    notes: "Rabies vaccine administered.",
+    // veterinarianName is optional, so we can omit it or pass null/undefined
+  });
+  yield* Effect.logInfo("Added another health record:", anotherHealthRecord);
+
+  // Retrieve all health records for the cat
+  const catHealthRecords = yield* healthRecordsService.getRecordsForCat(foundCat.id);
+  yield* Effect.logInfo(`Health records for ${foundCat.name}:`, catHealthRecords);
+
+  // --- Demonstrate Error Handling (Optional: find records for a non-existent cat) ---
+  const nonExistentCatId = "cat-non-existent" as CatId;
+  const recordsForNonExistentCat = yield* Effect.either(
+    healthRecordsService.getRecordsForCat(nonExistentCatId)
+  );
+  if (recordsForNonExistentCat._tag === "Left") {
+    yield* Effect.logWarning(`As expected, no records found for ${nonExistentCatId}: ${recordsForNonExistentCat.left._tag}`);
+  } else {
+    yield* Effect.logError("This should not happen: Found records for a non-existent cat.");
+  }
+
+  // --- Demonstrate finding a specific health record ---
+  const specificRecord = yield* healthRecordsService.getRecordById(newHealthRecord.recordId);
+  yield* Effect.logInfo("Found specific health record by ID:", specificRecord);
+
+  // --- Demonstrate Deleting a health record ---
+  yield* healthRecordsService.deleteRecord(anotherHealthRecord.recordId);
+  yield* Effect.logInfo(`Deleted health record ID: ${anotherHealthRecord.recordId}`);
+
+  // Try to retrieve the deleted record (should fail)
+  const deletedRecordRetrieval = yield* Effect.either(
+     healthRecordsService.getRecordById(anotherHealthRecord.recordId)
+  );
+  if (deletedRecordRetrieval._tag === "Left") {
+     yield* Effect.logInfo(`As expected, record ${anotherHealthRecord.recordId} not found after deletion: ${deletedRecordRetrieval.left._tag}`);
+  } else {
+     yield* Effect.logError("This should not happen: Deleted record was found.");
+  }
+
+  // Retrieve all health records for the cat again to see the change
+  const updatedCatHealthRecords = yield* healthRecordsService.getRecordsForCat(foundCat.id);
+  yield* Effect.logInfo(`Health records for ${foundCat.name} after deletion:`, updatedCatHealthRecords);
+
+
 });
 
-const AppLayer = Layer.merge(CatsLayer, CatsDataLayer);
+// Merge all layers: Cats context and Veterinary context
+const AppLayer = Layer.mergeAll(
+  CatsLayer,
+  CatsDataLayer,
+  HealthRecordsServiceLayer,
+  HealthRecordsDataLayer
+);
 
-//       ┌─── Effect<void, CatNotFoundError, never>
-//       ▼
 const runnableProgram = program.pipe(Effect.provide(AppLayer));
 
 const DevToolsLive = DevTools.layerWebSocket().pipe(
   Layer.provide(NodeSocket.layerWebSocketConstructor),
 );
 
+// Run the program
 pipe(runnableProgram, Effect.provide(DevToolsLive), NodeRuntime.runMain);

--- a/src/veterinary/data-access/health-records-data.ts
+++ b/src/veterinary/data-access/health-records-data.ts
@@ -1,0 +1,68 @@
+import { Array, Context, Effect, HashMap, Layer, Option, Ref } from "effect";
+import { CatId } from "../../domain/cats"; // Path to the original CatId
+import { HealthRecord, HealthRecordId } from "../domain/health-record";
+import { HealthRecordNotFoundError, CatHealthRecordsNotFoundError } from "../domain/errors";
+
+export class HealthRecordsData extends Context.Tag("HealthRecordsData")<
+  HealthRecordsData,
+  {
+    readonly findById: (id: HealthRecordId) => Effect.Effect<HealthRecord, HealthRecordNotFoundError>;
+    readonly persist: (record: HealthRecord) => Effect.Effect<void>;
+    readonly findAllByCatId: (catId: CatId) => Effect.Effect<ReadonlyArray<HealthRecord>, CatHealthRecordsNotFoundError>;
+    readonly removeById: (id: HealthRecordId) => Effect.Effect<void, HealthRecordNotFoundError>;
+    // Optional: A method to get all records, if needed for admin purposes
+    readonly findAll: () => Effect.Effect<ReadonlyArray<HealthRecord>>;
+  }
+>() {}
+
+export const makeHealthRecordsData = Effect.gen(function* () {
+  const healthRecordsState = yield* Ref.make(HashMap.empty<HealthRecordId, HealthRecord>());
+
+  const findById = (id: HealthRecordId): Effect.Effect<HealthRecord, HealthRecordNotFoundError> =>
+    Ref.get(healthRecordsState).pipe(
+      Effect.flatMap(HashMap.get(id)),
+      Effect.catchTag(
+        "NoSuchElementException",
+        () => Effect.fail(HealthRecordNotFoundError.of({ recordId: id }))
+      )
+    );
+
+  const persist = (record: HealthRecord): Effect.Effect<void> =>
+    Ref.update(healthRecordsState, HashMap.set(record.recordId, record));
+
+  const findAllByCatId = (catId: CatId): Effect.Effect<ReadonlyArray<HealthRecord>, CatHealthRecordsNotFoundError> =>
+    Ref.get(healthRecordsState).pipe(
+      Effect.map(HashMap.values),
+      Effect.map(Array.fromIterable),
+      Effect.map(records => records.filter(record => record.catId === catId)),
+      Effect.filterOrFail(
+        records => records.length > 0,
+        () => Effect.fail(CatHealthRecordsNotFoundError.of({ catId }))
+      )
+    );
+
+  const findAll = (): Effect.Effect<ReadonlyArray<HealthRecord>> =>
+     Ref.get(healthRecordsState).pipe(
+         Effect.map(HashMap.values),
+         Effect.map(Array.fromIterable)
+     );
+
+  const removeById = (id: HealthRecordId): Effect.Effect<void, HealthRecordNotFoundError> =>
+    Ref.get(healthRecordsState).pipe(
+      Effect.flatMap(recordsMap =>
+        HashMap.has(recordsMap, id)
+          ? Ref.update(healthRecordsState, HashMap.remove(id))
+          : Effect.fail(HealthRecordNotFoundError.of({ recordId: id }))
+      )
+    );
+
+  return {
+    findById,
+    persist,
+    findAllByCatId,
+    findAll,
+    removeById,
+  } as const;
+});
+
+export const HealthRecordsDataLayer = Layer.effect(HealthRecordsData, makeHealthRecordsData);

--- a/src/veterinary/data-access/tests/health-records-data.test.ts
+++ b/src/veterinary/data-access/tests/health-records-data.test.ts
@@ -1,0 +1,100 @@
+import { Effect, Layer, Option } from "effect";
+import { HealthRecordsData, HealthRecordsDataLayer, makeHealthRecordsData } from "../health-records-data";
+import { HealthRecord, HealthRecordId, HealthRecordEventType } from "../../domain/health-record";
+import { CatId } from "../../../domain/cats"; // Adjust path as necessary
+import { HealthRecordNotFoundError, CatHealthRecordsNotFoundError } from "../../domain/errors";
+
+// Mock data or factories would be useful here
+const createMockRecord = (id: string, catId: string, date = new Date()): HealthRecord =>
+  new HealthRecord({
+    recordId: id as HealthRecordId,
+    catId: catId as CatId,
+    date,
+    eventType: "Checkup" as HealthRecordEventType,
+    notes: "Test notes for " + id,
+    veterinarianName: Option.some("Dr. Test"),
+  });
+
+describe("HealthRecordsData", () => {
+  const testLayer = HealthRecordsDataLayer;
+
+  it("should persist and find a health record by ID", async () => {
+    // const program = Effect.gen(function* (_) {
+    //   const dataService = yield* _(HealthRecordsData);
+    //   const record = createMockRecord("record1", "cat1");
+    //   yield* _(dataService.persist(record));
+    //   const found = yield* _(dataService.findById(record.recordId));
+    //   expect(found).toEqual(record);
+    // });
+    // await Effect.runPromise(Effect.provide(program, testLayer));
+    console.log("Test: should persist and find a health record by ID - Placeholder");
+  });
+
+  it("should fail with HealthRecordNotFoundError when finding a non-existent record", async () => {
+    // const program = Effect.gen(function* (_) {
+    //   const dataService = yield* _(HealthRecordsData);
+    //   const result = yield* _(Effect.either(dataService.findById("nonexistent" as HealthRecordId)));
+    //   expect(result._tag).toBe("Left");
+    //   if (result._tag === "Left") {
+    //     expect(result.left).toBeInstanceOf(HealthRecordNotFoundError);
+    //   }
+    // });
+    // await Effect.runPromise(Effect.provide(program, testLayer));
+    console.log("Test: should fail with HealthRecordNotFoundError - Placeholder");
+  });
+
+  it("should find all records for a specific catId", async () => {
+    // const program = Effect.gen(function* (_) {
+    //   const dataService = yield* _(HealthRecordsData);
+    //   const cat1Record1 = createMockRecord("rec1cat1", "cat1");
+    //   const cat1Record2 = createMockRecord("rec2cat1", "cat1");
+    //   const cat2Record1 = createMockRecord("rec1cat2", "cat2");
+    //   yield* _(dataService.persist(cat1Record1));
+    //   yield* _(dataService.persist(cat1Record2));
+    //   yield* _(dataService.persist(cat2Record1));
+    //   const cat1Records = yield* _(dataService.findAllByCatId("cat1" as CatId));
+    //   expect(cat1Records).toHaveLength(2);
+    //   expect(cat1Records).toEqual(expect.arrayContaining([cat1Record1, cat1Record2]));
+    // });
+    // await Effect.runPromise(Effect.provide(program, testLayer));
+    console.log("Test: should find all records for a specific catId - Placeholder");
+  });
+
+  it("should fail with CatHealthRecordsNotFoundError if no records exist for a catId", async () => {
+     // const program = Effect.gen(function* (_) {
+     // const dataService = yield* _(HealthRecordsData);
+     // const result = yield* _(Effect.either(dataService.findAllByCatId("cat-nonexistent" as CatId)));
+     // expect(result._tag).toBe("Left");
+     // if (result._tag === "Left") {
+     //  expect(result.left).toBeInstanceOf(CatHealthRecordsNotFoundError);
+     // }
+     // });
+     // await Effect.runPromise(Effect.provide(program, testLayer));
+     console.log("Test: should fail with CatHealthRecordsNotFoundError - Placeholder");
+  });
+
+  it("should remove a record by ID", async () => {
+    // const program = Effect.gen(function* (_) {
+    //   const dataService = yield* _(HealthRecordsData);
+    //   const record = createMockRecord("recordToRemove", "catX");
+    //   yield* _(dataService.persist(record));
+    //   yield* _(dataService.removeById(record.recordId));
+    //   const result = yield* _(Effect.either(dataService.findById(record.recordId)));
+    //   expect(result._tag).toBe("Left"); // Should not be found
+    // });
+    // await Effect.runPromise(Effect.provide(program, testLayer));
+    console.log("Test: should remove a record by ID - Placeholder");
+  });
+
+  it("should return all records with findAll", async () => {
+     // const program = Effect.gen(function* (_) {
+     // const dataService = yield* _(HealthRecordsData);
+     // yield* _(dataService.persist(createMockRecord("r1", "c1")));
+     // yield* _(dataService.persist(createMockRecord("r2", "c2")));
+     // const allRecords = yield* _(dataService.findAll());
+     // expect(allRecords.length).toBeGreaterThanOrEqual(2); // Could be more if tests run sequentially and don't clean up
+     // });
+     // await Effect.runPromise(Effect.provide(program, Layer.fresh(testLayer))); // Use Layer.fresh for isolation
+     console.log("Test: should return all records with findAll - Placeholder");
+  });
+});

--- a/src/veterinary/domain/errors.ts
+++ b/src/veterinary/domain/errors.ts
@@ -1,0 +1,23 @@
+import { Schema } from "effect";
+
+export class HealthRecordNotFoundError extends Schema.TaggedError<HealthRecordNotFoundError>()(
+  "HealthRecordNotFoundError",
+  {
+    recordId: Schema.String, // Or CatId if searching by CatId and none are found
+    message: Schema.String, // Optional: provide a more descriptive message
+  },
+) {
+  static of = (input: { recordId: string, message?: string }) =>
+    new HealthRecordNotFoundError({ ...input, message: input.message || `Health record with ID ${input.recordId} not found.` });
+}
+
+export class CatHealthRecordsNotFoundError extends Schema.TaggedError<CatHealthRecordsNotFoundError>()(
+ "CatHealthRecordsNotFoundError",
+ {
+   catId: Schema.String,
+   message: Schema.String,
+ }
+) {
+ static of = (input: { catId: string, message?: string }) =>
+   new CatHealthRecordsNotFoundError({ ...input, message: input.message || `No health records found for cat ID ${input.catId}.` });
+}

--- a/src/veterinary/domain/health-record.ts
+++ b/src/veterinary/domain/health-record.ts
@@ -1,0 +1,20 @@
+import { Schema } from "effect";
+import { CatId } from "../../domain/cats"; // Assuming CatId will be imported from the existing cats domain
+
+// HealthRecordId
+export const HealthRecordId = Schema.String.pipe(Schema.brand("HealthRecordId"));
+export type HealthRecordId = typeof HealthRecordId.Type;
+
+// EventType for health records
+export const HealthRecordEventType = Schema.Literal("Vaccination", "Checkup", "Medication", "Routine Visit", "Emergency");
+export type HealthRecordEventType = typeof HealthRecordEventType.Type;
+
+// HealthRecord Schema
+export class HealthRecord extends Schema.Class<HealthRecord>("HealthRecord")({
+  recordId: HealthRecordId,
+  catId: CatId, // Linking to the Cat from the original context
+  date: Schema.Date,
+  eventType: HealthRecordEventType,
+  notes: Schema.String,
+  veterinarianName: Schema.OptionFromNullOr(Schema.String), // Optional: name of the vet
+}) {}

--- a/src/veterinary/services/health-records.ts
+++ b/src/veterinary/services/health-records.ts
@@ -1,0 +1,80 @@
+import { Context, Effect, Layer } from "effect";
+import { HealthRecordsData } from "../data-access/health-records-data";
+import { HealthRecord, HealthRecordId } from "../domain/health-record";
+import { CatId } from "../../domain/cats"; // Path to the original CatId
+import { HealthRecordNotFoundError, CatHealthRecordsNotFoundError } from "../domain/errors";
+
+// Define the interface for the service
+export class HealthRecordsService extends Context.Tag("HealthRecordsService")<
+  HealthRecordsService,
+  {
+    readonly addRecord: (recordDetails: {
+      catId: CatId;
+      date: Date;
+      eventType: HealthRecord["eventType"];
+      notes: string;
+      veterinarianName?: string | null; // Making it optional as in the schema
+    }) => Effect.Effect<HealthRecord>; // Returns the created record
+    readonly getRecordsForCat: (catId: CatId) => Effect.Effect<ReadonlyArray<HealthRecord>, CatHealthRecordsNotFoundError>;
+    readonly getRecordById: (recordId: HealthRecordId) => Effect.Effect<HealthRecord, HealthRecordNotFoundError>;
+    readonly deleteRecord: (recordId: HealthRecordId) => Effect.Effect<void, HealthRecordNotFoundError>;
+  }
+>() {}
+
+// Implementation of the service
+export const makeHealthRecordsService = Effect.gen(function* () {
+  const healthRecordsData = yield* HealthRecordsData;
+
+  // Function to generate a new HealthRecordId - simple version for now
+  const generateRecordId = () => Effect.sync(() => `record-${Math.random().toString(36).substring(2, 9)}` as HealthRecordId);
+
+  const addRecord = Effect.fn("HealthRecordsService.addRecord")(
+    function* (recordDetails: {
+      catId: CatId;
+      date: Date;
+      eventType: HealthRecord["eventType"];
+      notes: string;
+      veterinarianName?: string | null;
+    }) {
+      const newRecordId = yield* generateRecordId();
+      const record = new HealthRecord({
+        ...recordDetails,
+        recordId: newRecordId,
+        veterinarianName: recordDetails.veterinarianName ?? undefined, // Handle null to Option
+      });
+      yield* Effect.log("Adding health record").pipe(Effect.annotateLogs({ catId: record.catId, recordId: record.recordId }));
+      yield* healthRecordsData.persist(record);
+      return record;
+    }
+  );
+
+  const getRecordsForCat = Effect.fn("HealthRecordsService.getRecordsForCat")(
+    function* (catId: CatId) {
+      yield* Effect.log("Getting health records for cat").pipe(Effect.annotateLogs({ catId }));
+      return yield* healthRecordsData.findAllByCatId(catId);
+    }
+  );
+
+  const getRecordById = Effect.fn("HealthRecordsService.getRecordById")(
+    function* (recordId: HealthRecordId) {
+      yield* Effect.log("Getting health record by ID").pipe(Effect.annotateLogs({ recordId }));
+      return yield* healthRecordsData.findById(recordId);
+    }
+  );
+
+  const deleteRecord = Effect.fn("HealthRecordsService.deleteRecord")(
+    function* (recordId: HealthRecordId) {
+      yield* Effect.log("Deleting health record").pipe(Effect.annotateLogs({ recordId }));
+      return yield* healthRecordsData.removeById(recordId);
+    }
+  );
+
+  return {
+    addRecord,
+    getRecordsForCat,
+    getRecordById,
+    deleteRecord,
+  } as const;
+});
+
+export const HealthRecordsServiceLayer = Layer.effect(HealthRecordsService, makeHealthRecordsService);

--- a/src/veterinary/services/tests/health-records.service.test.ts
+++ b/src/veterinary/services/tests/health-records.service.test.ts
@@ -1,0 +1,116 @@
+import { Effect, Layer, Option } from "effect";
+import { HealthRecordsService, HealthRecordsServiceLayer, makeHealthRecordsService } from "../health-records";
+import { HealthRecordsData, HealthRecordsDataLayer, makeHealthRecordsData } from "../../data-access/health-records-data";
+import { HealthRecord, HealthRecordId, HealthRecordEventType } from "../../domain/health-record";
+import { CatId } from "../../../domain/cats"; // Adjust path
+import { HealthRecordNotFoundError, CatHealthRecordsNotFoundError } from "../../domain/errors";
+
+// More comprehensive mocking might be needed for data layer interactions
+const mockHealthRecordsData = Layer.succeed(
+  HealthRecordsData,
+  HealthRecordsData.of({
+    findById: (id) => Effect.fail(new HealthRecordNotFoundError({recordId: id, message: "Mock Not Found"})),
+    persist: (record) => Effect.void,
+    findAllByCatId: (catId) => Effect.fail(new CatHealthRecordsNotFoundError({catId, message: "Mock Not Found"})),
+    findAll: () => Effect.succeed([]),
+    removeById: (id) => Effect.fail(new HealthRecordNotFoundError({recordId: id, message: "Mock Not Found"})),
+    // Add more mock implementations as needed for specific tests
+  })
+);
+
+// A more stateful mock if needed for some tests:
+// const liveTestDataLayer = Layer.provide(HealthRecordsDataLayer, Layer.fresh(makeHealthRecordsData));
+
+
+describe("HealthRecordsService", () => {
+  // This layer will use the actual data layer for integration-style service tests
+  const testServiceLayer = Layer.provide(HealthRecordsServiceLayer, HealthRecordsDataLayer);
+  // Or, for more unit-style tests, provide a mocked data layer:
+  // const testServiceLayerWithMockData = Layer.provide(HealthRecordsServiceLayer, mockHealthRecordsData);
+
+
+  it("should add a health record and return it", async () => {
+    // const program = Effect.gen(function* (_) {
+    //   const service = yield* _(HealthRecordsService);
+    //   const recordDetails = {
+    //     catId: "catTest" as CatId,
+    //     date: new Date(),
+    //     eventType: "Vaccination" as HealthRecordEventType,
+    //     notes: "Test vaccine",
+    //     veterinarianName: Option.some("Dr. ServiceTest")
+    //   };
+    //   const addedRecord = yield* _(service.addRecord(recordDetails));
+    //   expect(addedRecord).toBeDefined();
+    //   expect(addedRecord.catId).toBe(recordDetails.catId);
+    //   expect(addedRecord.notes).toBe(recordDetails.notes);
+    //   expect(addedRecord.recordId).toBeDefined();
+    // });
+    // // Provide a fresh data layer for each test if they interact with state
+    // await Effect.runPromise(Effect.provide(program, Layer.provide(HealthRecordsServiceLayer, Layer.fresh(HealthRecordsDataLayer))));
+    console.log("Test: should add a health record and return it - Placeholder");
+  });
+
+  it("should retrieve records for a cat", async () => {
+    // const program = Effect.gen(function* (_) {
+    //   const service = yield* _(HealthRecordsService);
+    //   const catId = "catWithRecords" as CatId;
+    //   // Pre-populate data or use a mock that returns specific records
+    //   yield* _(service.addRecord({ catId, date: new Date(), eventType: "Checkup", notes: "Note 1"}));
+    //   yield* _(service.addRecord({ catId, date: new Date(), eventType: "Vaccination", notes: "Note 2"}));
+    //
+    //   const records = yield* _(service.getRecordsForCat(catId));
+    //   expect(records).toHaveLength(2);
+    // });
+    // await Effect.runPromise(Effect.provide(program, Layer.provide(HealthRecordsServiceLayer, Layer.fresh(HealthRecordsDataLayer))));
+    console.log("Test: should retrieve records for a cat - Placeholder");
+  });
+
+  it("should return CatHealthRecordsNotFoundError when no records for a cat", async () => {
+     // const program = Effect.gen(function* (_) {
+     // const service = yield* _(HealthRecordsService);
+     // const result = yield* _(Effect.either(service.getRecordsForCat("catNoRecords" as CatId)));
+     // expect(result._tag).toBe("Left");
+     // if (result._tag === "Left") {
+     //  expect(result.left).toBeInstanceOf(CatHealthRecordsNotFoundError);
+     // }
+     // });
+     // await Effect.runPromise(Effect.provide(program, testServiceLayer)); // Can use shared layer if no side effects
+     console.log("Test: CatHealthRecordsNotFoundError for no records - Placeholder");
+  });
+
+  it("should get a specific record by ID", async () => {
+     // const program = Effect.gen(function* (_) {
+     // const service = yield* _(HealthRecordsService);
+     // const addedRecord = yield* _(service.addRecord({catId: "catForGetById" as CatId, date: new Date(), eventType: "Medication", notes: "Test med"}));
+     // const foundRecord = yield* _(service.getRecordById(addedRecord.recordId));
+     // expect(foundRecord).toEqual(addedRecord);
+     // });
+     // await Effect.runPromise(Effect.provide(program, Layer.provide(HealthRecordsServiceLayer, Layer.fresh(HealthRecordsDataLayer))));
+     console.log("Test: should get a specific record by ID - Placeholder");
+  });
+
+  it("should return HealthRecordNotFoundError for non-existent record ID", async () => {
+     // const program = Effect.gen(function* (_) {
+     // const service = yield* _(HealthRecordsService);
+     // const result = yield* _(Effect.either(service.getRecordById("nonExistentRecId" as HealthRecordId)));
+     // expect(result._tag).toBe("Left");
+     // if (result._tag === "Left") {
+     //  expect(result.left).toBeInstanceOf(HealthRecordNotFoundError);
+     // }
+     // });
+     // await Effect.runPromise(Effect.provide(program, testServiceLayer));
+     console.log("Test: HealthRecordNotFoundError for non-existent ID - Placeholder");
+  });
+
+  it("should delete a record by ID", async () => {
+     // const program = Effect.gen(function* (_) {
+     // const service = yield* _(HealthRecordsService);
+     // const addedRecord = yield* _(service.addRecord({catId: "catForDelete" as CatId, date: new Date(), eventType: "Emergency", notes: "Test emergency"}));
+     // yield* _(service.deleteRecord(addedRecord.recordId));
+     // const result = yield* _(Effect.either(service.getRecordById(addedRecord.recordId)));
+     // expect(result._tag).toBe("Left"); // Should not be found
+     // });
+     // await Effect.runPromise(Effect.provide(program, Layer.provide(HealthRecordsServiceLayer, Layer.fresh(HealthRecordsDataLayer))));
+     console.log("Test: should delete a record by ID - Placeholder");
+  });
+});


### PR DESCRIPTION
feat: Add Veterinary bounded context for cat health records

This commit introduces a new 'Veterinary' bounded context to manage health-related information for cats. This demonstrates the application of Domain-Driven Design principles to separate concerns and model distinct parts of the domain.

New components:
- **Veterinary Domain (`src/veterinary/domain`):**
    - Defines `HealthRecord` entity with properties like `recordId`, `catId`, `date`, `eventType`, `notes`.
    - Includes `HealthRecordId` and `HealthRecordEventType`.
    - Defines `HealthRecordNotFoundError` and `CatHealthRecordsNotFoundError`.

- **Veterinary Data Access (`src/veterinary/data-access`):**
    - Implements `HealthRecordsData` for in-memory storage of health records using Effect-TS `Ref` and `HashMap`.
    - Provides `HealthRecordsDataLayer`.
    - Includes placeholder test file `health-records-data.test.ts`.

- **Veterinary Services (`src/veterinary/services`):**
    - Implements `HealthRecordsService` for business logic related to health records (add, find, delete).
    - Provides `HealthRecordsServiceLayer`.
    - Includes placeholder test file `health-records.service.test.ts`.

- **Integration (`src/index.ts`):**
    - Merges new layers (`HealthRecordsServiceLayer`, `HealthRecordsDataLayer`) into the main `AppLayer`.
    - Demonstrates creating a cat, adding health records, and retrieving them.

- **Build (`package.json`):**
    - Added `tsx` as a dev dependency.
    - Added an `npm start` script for running `src/index.ts`.

This new context coexists with the original 'Cats' context, linked by `CatId`, showcasing how different domain models can interact while maintaining their own boundaries and language.