### PR TITLE
feat: Add Cat management endpoints using Effect/Platform

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,12 @@
       "dependencies": {
         "@effect/experimental": "^0.44.19",
         "@effect/platform-node": "^0.77.8",
-        "effect": "^3.14.19"
+        "effect": "^3.14.19",
+        "uuid": "^11.1.0"
       },
       "devDependencies": {
         "@biomejs/biome": "2.0.0-beta.2",
+        "@types/uuid": "^10.0.0",
         "typescript": "^5.8.3"
       }
     },
@@ -691,6 +693,12 @@
       "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
       "license": "MIT"
     },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "dev": true
+    },
     "node_modules/braces": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
@@ -964,7 +972,6 @@
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
-      "license": "MIT",
       "bin": {
         "uuid": "dist/esm/bin/uuid"
       }

--- a/package.json
+++ b/package.json
@@ -11,11 +11,13 @@
   "description": "",
   "devDependencies": {
     "@biomejs/biome": "2.0.0-beta.2",
+    "@types/uuid": "^10.0.0",
     "typescript": "^5.8.3"
   },
   "dependencies": {
     "@effect/experimental": "^0.44.19",
     "@effect/platform-node": "^0.77.8",
-    "effect": "^3.14.19"
+    "effect": "^3.14.19",
+    "uuid": "^11.1.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,9 +2,9 @@ import { DevTools } from "@effect/experimental";
 import { NodeRuntime, NodeSocket, NodeHttpServer, HttpServer } from "@effect/platform-node";
 import { Router } from "@effect/platform";
 import { Effect, Layer, pipe } from "effect";
-import catRoutes, { CatsService, InMemoryCatsServiceLive } from "./routes/cat-routes";
-// import { Cats, CatsLayer } from "./services/cats"; // Original Cats service
-import { CatsDataLayer } from "./data-access/cats-data"; // Assuming this is still needed for a more complete service
+import catRoutes from "./routes/cat-routes"; // InMemoryCatsServiceLive and CatsService removed
+import { CatsLayer } from "./services/cats"; // Uncommented and Cats tag removed as it's not used directly here
+import { CatsDataLayer } from "./data-access/cats-data";
 
 // Define the main router, integrating catRoutes
 // It's common to prefix API routes, e.g., under /api
@@ -22,11 +22,9 @@ const HttpApp = HttpServer.serve(AppRouter).pipe(
 const program = HttpApp;
 
 // Define the application layer
-// Providing InMemoryCatsServiceLive for the CatsService tag used in catRoutes.
-// CatsDataLayer is kept as per original structure, though InMemoryCatsServiceLive is self-contained.
-// If CatsLayer (from ./services/cats) is the intended provider for CatsService,
-// it would replace InMemoryCatsServiceLive, assuming compatibility.
-const AppLayer = Layer.merge(InMemoryCatsServiceLive, CatsDataLayer);
+// Define the application layer
+// Now providing the actual CatsLayer and CatsDataLayer.
+const AppLayer = Layer.merge(CatsLayer, CatsDataLayer);
 
 //       ┌─── Effect<never, Error, void> - this is the typical signature for a server program
 //       ▼


### PR DESCRIPTION
This commit introduces a new set of HTTP endpoints for managing cats. The endpoints are built using Effect/Platform and provide CRUD operations for cats.

The following routes have been added:
- GET /api/cats: Retrieves all cats.
- GET /api/cats/:id: Retrieves a specific cat by its ID.
- POST /api/cats: Creates a new cat.
- PUT /api/cats/:id: Updates an existing cat.
- DELETE /api/cats/:id: Deletes a cat by its ID.

The implementation follows a layered architecture, with HTTP handlers defined in `src/routes/cat-routes.ts` that utilize the existing `Cats` service. Unit tests have been added in `src/routes/cat-routes.test.ts` to ensure the correct functionality of these new endpoints, covering success and error scenarios. The main application in `src/index.ts` has been updated to serve these routes.