### PR TITLE
feat: Add Swagger docs link and schema annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The following API endpoints are available:
 *   `PATCH /cats/:id`: Update an existing cat.
     *   Payload: `{ "name"?: "string", "breed"?: "string", "age"?: "number" }`
 *   `DELETE /cats/:id`: Delete a cat by its ID.
+*   Swagger UI: `http://localhost:3000/docs`
 
 ## Getting Started
 

--- a/packages/domain/src/Cats.ts
+++ b/packages/domain/src/Cats.ts
@@ -8,8 +8,20 @@ export const CatIdFromString = Schema.NumberFromString.pipe(
 );
 
 export class Cat extends Schema.Class<Cat>("Cat")({
-  id: CatId,
-  name: Schema.NonEmptyTrimmedString,
-  breed: Schema.NonEmptyTrimmedString,
-  age: Schema.Number,
+  id: CatId.pipe(
+    Schema.description("The unique identifier for the cat."),
+    Schema.examples([123]),
+  ),
+  name: Schema.NonEmptyTrimmedString.pipe(
+    Schema.description("The name of the cat."),
+    Schema.examples(["Whiskers"]),
+  ),
+  breed: Schema.NonEmptyTrimmedString.pipe(
+    Schema.description("The breed of the cat."),
+    Schema.examples(["Siamese"]),
+  ),
+  age: Schema.Number.pipe(
+    Schema.description("The age of the cat in years."),
+    Schema.examples([2]),
+  ),
 }) {}


### PR DESCRIPTION
- Added a link to the Swagger UI endpoint (http://localhost:3000/docs) in the README.md.
- Added descriptions and examples to the Cat schema in packages/domain/src/Cats.ts for better API documentation.