### PR TITLE
feat: Add Swagger docs link and corrected schema annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The following API endpoints are available:
 *   `PATCH /cats/:id`: Update an existing cat.
     *   Payload: `{ "name"?: "string", "breed"?: "string", "age"?: "number" }`
 *   `DELETE /cats/:id`: Delete a cat by its ID.
+*   Swagger UI: `http://localhost:3000/docs`
 
 ## Getting Started
 

--- a/packages/domain/src/Cats.ts
+++ b/packages/domain/src/Cats.ts
@@ -8,8 +8,20 @@ export const CatIdFromString = Schema.NumberFromString.pipe(
 );
 
 export class Cat extends Schema.Class<Cat>("Cat")({
-  id: CatId,
-  name: Schema.NonEmptyTrimmedString,
-  breed: Schema.NonEmptyTrimmedString,
-  age: Schema.Number,
+  id: CatId.annotations({
+    description: "The unique identifier for the cat.",
+    examples: [123],
+  }),
+  name: Schema.NonEmptyTrimmedString.annotations({
+    description: "The name of the cat.",
+    examples: ["Whiskers", "Luna"],
+  }),
+  breed: Schema.NonEmptyTrimmedString.annotations({
+    description: "The breed of the cat.",
+    examples: ["Siamese", "Maine Coon"],
+  }),
+  age: Schema.Number.annotations({
+    description: "The age of the cat in years.",
+    examples: [2, 5],
+  }),
 }) {}


### PR DESCRIPTION
- Added a link to the Swagger UI endpoint (http://localhost:3000/docs) in the README.md.
- Added descriptions and examples to the Cat schema in packages/domain/src/Cats.ts using the .annotations() method for better API documentation.