### PR TITLE
feat: Add deathDate and related logic to Cat entity

### DIFF
--- a/domain/entities/cat.test.ts
+++ b/domain/entities/cat.test.ts
@@ -1,68 +1,261 @@
 import { describe, it } from "https://deno.land/std@0.220.0/testing/bdd.ts";
 import { expect } from "https://deno.land/std@0.220.0/expect/mod.ts";
 import { Effect, Either, Schema } from "effect";
+// Removed import of ParseError, ParseIssue as they are not directly exported or needed for current error checking.
 import { Cat } from "./cat.ts";
 import { CatId } from "../value-objects/cat.ts";
 
+// Define a type for the raw input data for creating/updating cats in tests.
+// This should align with Schema.Schema.Encoded<typeof Cat> but simplified for partial inputs.
+type TestCatRawInput = Partial<{
+  id: number; // CatId is number | Brand<"CatId">, number is fine for input
+  name: string;
+  breed: string;
+  birthDate: Date | string; // Allow string for birthDate as it might be decoded
+  deathDate?: Date | string | null; // Allow string or null as well
+}>;
+
 /**
  * Helper function to create a Cat instance for testing purposes.
- * Uses Schema.decodeUnknownSync for convenience, assuming valid test data.
  */
 const createTestCatObject = (
   birthDate: Date,
-  overrides: Partial<Cat> = {},
+  props: TestCatRawInput = {},
 ): Cat => {
-  const catData = {
-    id: 1 as CatId,
+  const finalProps: Record<string, any> = { ...props };
+  if (props.birthDate instanceof Date) {
+    finalProps.birthDate = props.birthDate.toISOString();
+  }
+  if (props.deathDate instanceof Date) {
+    finalProps.deathDate = props.deathDate.toISOString();
+  }
+
+  const rawCatData = {
+    id: 1,
     name: "Test Cat",
     breed: "Test Breed",
-    birthDate: birthDate.toISOString(),
-    ...overrides,
+    birthDate: birthDate.toISOString(), // Convert main birthDate argument
+    deathDate: undefined, // Default, can be overridden by finalProps
+    ...finalProps,
   };
-  return Schema.decodeUnknownSync(Cat)(catData);
+  return Schema.decodeUnknownSync(Cat)(rawCatData);
 };
 
+/**
+ * Helper function to attempt to create a Cat instance and expect a failure.
+ */
+const expectCatCreationFailure = (
+  birthDateInput: Date | string,
+  props: TestCatRawInput = {},
+  expectedErrorMessageSubString: string,
+) => {
+  const finalProps: Record<string, any> = { ...props };
+  if (props.birthDate instanceof Date) {
+    finalProps.birthDate = props.birthDate.toISOString();
+  }
+  if (props.deathDate instanceof Date) {
+    finalProps.deathDate = props.deathDate.toISOString();
+  }
+
+  const rawCatData = {
+    id: 1,
+    name: "Test Cat",
+    breed: "Test Breed",
+    birthDate: birthDateInput instanceof Date ? birthDateInput.toISOString() : birthDateInput,
+    deathDate: undefined, // Default
+    ...finalProps,
+  };
+  const result = Effect.runSync(Effect.either(Schema.decodeUnknown(Cat)(rawCatData)));
+  expect(Either.isLeft(result)).toBe(true);
+  if (Either.isLeft(result)) {
+    // The .message property on the error (even if just `Error`) usually gives a good summary.
+    // For ParseError, this message is typically well-formatted.
+    expect(result.left.message).toContain(expectedErrorMessageSubString);
+  }
+};
+
+
 describe("Cat Entity", () => {
-  describe("getAgeAt", () => {
-    // A fixed date used as the "current" date in tests to ensure consistent age calculations.
-    const commonTestDate = new Date("2023-06-15T10:00:00.000Z");
+  const commonTestDate = new Date("2023-06-15T10:00:00.000Z"); // A fixed "current" date
 
+  describe("Schema Validations", () => {
     it("should fail to create a cat with a birthDate in the future", () => {
-      // Attempts to create a cat with a birth date set to one hundred years after commonTestDate.
+      // Create a date that is guaranteed to be in the future from runtime
+      const tomorrow = new Date(Date.now() + 24 * 60 * 60 * 1000);
       const futureBirthDate = new Date(
-        commonTestDate.getTime() + 100 * 365 * 24 * 60 * 60 * 1000,
-      ); // commonTestDate + 100 years
-      const catData = {
-        id: 2 as CatId,
-        name: "Future Cat",
-        breed: "Time Traveler",
-        birthDate: futureBirthDate.toISOString(),
-      };
-
-      const result = Effect.runSync(
-        Effect.either(Schema.decodeUnknown(Cat)(catData)),
+        tomorrow.getUTCFullYear() + 1, // Make it one year from tomorrow
+        tomorrow.getUTCMonth(),
+        tomorrow.getUTCDate(),
       );
-      expect(Either.isLeft(result)).toBe(true);
-      if (Either.isLeft(result)) {
-        // Further check if the error message is as expected for a birth date in the future.
-        // This depends on the exact error message defined in the Cat schema.
-        expect(result.left.message).toContain("Birth date must be in the past");
-      }
+      expectCatCreationFailure(
+        futureBirthDate,
+        {},
+        "Birth date must be in the past",
+      );
     });
 
-    it("should correctly calculate age for a cat whose birthday has passed this year", () => {
-      // Cat born May 10, 2021. Current test date is June 15, 2023. Expected age: 2.
+    it("should fail if deathDate is before birthDate", () => {
+      const birthDate = new Date("2020-01-01T00:00:00.000Z");
+      const deathDate = new Date("2019-12-31T00:00:00.000Z");
+      expectCatCreationFailure(
+        birthDate,
+        { deathDate },
+        "Death date must be after birth date",
+      );
+    });
+
+    it("should fail if deathDate is the same as birthDate", () => {
+      const birthDate = new Date("2020-01-01T00:00:00.000Z");
+      expectCatCreationFailure(
+        birthDate,
+        { deathDate: birthDate },
+        "Death date must be after birth date",
+      );
+    });
+
+    it("should successfully create a cat with valid birthDate and no deathDate", () => {
+      const birthDate = new Date("2020-01-01T00:00:00.000Z");
+      const cat = createTestCatObject(birthDate);
+      expect(cat).toBeInstanceOf(Cat);
+      expect(cat.birthDate).toEqual(birthDate);
+      expect(cat.deathDate).toBeUndefined();
+    });
+
+    it("should successfully create a cat with valid birthDate and deathDate", () => {
+      const birthDate = new Date("2020-01-01T00:00:00.000Z");
+      const deathDate = new Date("2022-01-01T00:00:00.000Z");
+      const cat = createTestCatObject(birthDate, { deathDate });
+      expect(cat).toBeInstanceOf(Cat);
+      expect(cat.birthDate).toEqual(birthDate);
+      expect(cat.deathDate).toEqual(deathDate);
+    });
+  });
+
+  describe("isAlive getter", () => {
+    it("should be true if deathDate is undefined", () => {
+      const cat = createTestCatObject(new Date("2020-01-01T00:00:00.000Z"));
+      expect(cat.isAlive).toBe(true);
+    });
+
+    it("should be false if deathDate is set", () => {
+      const cat = createTestCatObject(new Date("2020-01-01T00:00:00.000Z"), {
+        deathDate: new Date("2021-01-01T00:00:00.000Z"),
+      });
+      expect(cat.isAlive).toBe(false);
+    });
+  });
+
+  describe("getAgeAt", () => {
+    it("should return 0 if the date is before birthDate", () => {
       const birthDate = new Date("2021-05-10T00:00:00.000Z");
       const cat = createTestCatObject(birthDate);
-      expect(cat.getAgeAt(commonTestDate)).toBe(2);
+      const beforeBirth = new Date("2020-01-01T00:00:00.000Z");
+      expect(cat.getAgeAt(beforeBirth)).toBe(0);
     });
 
-    it("should correctly calculate age for a cat whose birthday is yet to come this year", () => {
-      // Cat born August 20, 2019. Current test date is June 15, 2023. Expected age: 3.
-      // (Birthday for 2023 hasn't occurred yet relative to commonTestDate).
-      const birthDate = new Date("2019-08-20T00:00:00.000Z");
+    it("should correctly calculate age for a living cat whose birthday has passed this year", () => {
+      const birthDate = new Date("2021-05-10T00:00:00.000Z"); // Born May 10, 2021
       const cat = createTestCatObject(birthDate);
-      expect(cat.getAgeAt(commonTestDate)).toBe(3);
+      expect(cat.getAgeAt(commonTestDate)).toBe(2); // commonTestDate is June 15, 2023
+    });
+
+    it("should correctly calculate age for a living cat whose birthday is yet to come this year", () => {
+      const birthDate = new Date("2019-08-20T00:00:00.000Z"); // Born Aug 20, 2019
+      const cat = createTestCatObject(birthDate);
+      expect(cat.getAgeAt(commonTestDate)).toBe(3); // commonTestDate is June 15, 2023
+    });
+
+    it("should correctly calculate age for a cat that is exactly 1 year old", () => {
+      const birthDate = new Date("2022-06-15T00:00:00.000Z");
+      const cat = createTestCatObject(birthDate);
+      expect(cat.getAgeAt(commonTestDate)).toBe(1); // commonTestDate is June 15, 2023
+    });
+
+    it("should correctly calculate age for a cat that is just under 1 year old", () => {
+      const birthDate = new Date("2022-06-16T00:00:00.000Z"); // Born June 16, 2022
+      const cat = createTestCatObject(birthDate);
+      expect(cat.getAgeAt(commonTestDate)).toBe(0); // commonTestDate is June 15, 2023
+    });
+
+    // Tests for deceased cats
+    it("should calculate age at death if date is after deathDate", () => {
+      const birthDate = new Date("2010-01-01T00:00:00.000Z");
+      const deathDate = new Date("2015-01-01T00:00:00.000Z"); // Died at 5 years old
+      const cat = createTestCatObject(birthDate, { deathDate });
+      const afterDeath = new Date("2020-01-01T00:00:00.000Z");
+      expect(cat.getAgeAt(afterDeath)).toBe(5);
+    });
+
+    it("should calculate age based on given date if date is before deathDate", () => {
+      const birthDate = new Date("2010-01-01T00:00:00.000Z");
+      const deathDate = new Date("2015-01-01T00:00:00.000Z"); // Died at 5
+      const cat = createTestCatObject(birthDate, { deathDate });
+      const beforeDeath = new Date("2013-01-01T00:00:00.000Z"); // Cat was 3
+      expect(cat.getAgeAt(beforeDeath)).toBe(3);
+    });
+
+    it("should calculate age as age at death if date is exactly deathDate", () => {
+      const birthDate = new Date("2010-01-01T00:00:00.000Z");
+      const deathDate = new Date("2015-06-15T00:00:00.000Z"); // Died at 5 years, 5 months, 14 days
+      const cat = createTestCatObject(birthDate, { deathDate });
+      expect(cat.getAgeAt(deathDate)).toBe(5); // Age is 5 full years
+    });
+  });
+
+  describe("age getter (current age)", () => {
+    let originalDateNow = Date.now;
+    let originalDateConstructor = globalThis.Date;
+
+    const mockCurrentDate = (fixedDate: Date) => {
+      originalDateNow = Date.now;
+      originalDateConstructor = globalThis.Date;
+
+      globalThis.Date = class extends originalDateConstructor {
+        constructor(...args: any[]) {
+          // If new Date() is called with no arguments, return the fixedDate.
+          // Otherwise, behave as original Date constructor.
+          if (args.length === 0) {
+            super(fixedDate.toISOString()); // Pass ISO string to ensure it's treated as specific date
+          } else {
+            super(...(args as [any])); // Use type assertion for spread
+          }
+        }
+
+        static override now(): number { // Add override modifier
+          return fixedDate.getTime();
+        }
+      } as any; // Cast to any due to complex Date constructor signature
+    };
+
+    const unmockCurrentDate = () => {
+      Date.now = originalDateNow;
+      globalThis.Date = originalDateConstructor;
+    };
+
+    it("should return current age for a living cat (using commonTestDate as 'now')", () => {
+      mockCurrentDate(commonTestDate);
+      const birthDate = new Date("2021-05-10T00:00:00.000Z");
+      const cat = createTestCatObject(birthDate);
+      expect(cat.age).toBe(2);
+      unmockCurrentDate();
+    });
+
+    it("should return age at death for a deceased cat (using commonTestDate as 'now')", () => {
+      mockCurrentDate(commonTestDate);
+      const birthDate = new Date("2010-01-01T00:00:00.000Z");
+      const deathDate = new Date("2015-01-01T00:00:00.000Z");
+      const cat = createTestCatObject(birthDate, { deathDate });
+      expect(cat.age).toBe(5);
+      unmockCurrentDate();
+    });
+
+    it("should return current age if cat died in the future (using commonTestDate as 'now')", () => {
+      mockCurrentDate(commonTestDate);
+      const birthDate = new Date("2020-01-01T00:00:00.000Z");
+      const futureDeathDate = new Date("2024-01-01T00:00:00.000Z");
+      const cat = createTestCatObject(birthDate, { deathDate: futureDeathDate });
+      expect(cat.age).toBe(3);
+      unmockCurrentDate();
     });
   });
 });

--- a/domain/entities/cat.ts
+++ b/domain/entities/cat.ts
@@ -1,7 +1,8 @@
-import { Schema } from "effect";
+import { Schema, pipe } from "effect"; // Import pipe
 import { CatId } from "../value-objects/cat.ts";
 
-export class Cat extends Schema.Class<Cat>("Cat")({
+// Define the core fields first for type inference within filterOrFail
+const catFields = {
   id: CatId.annotations({
     description: "The ID of the cat",
   }),
@@ -14,7 +15,7 @@ export class Cat extends Schema.Class<Cat>("Cat")({
     examples: ["Siamese", "Persian", "Maine Coon"],
   }),
   birthDate: Schema.Date.pipe(
-    Schema.lessThanDate(new Date(), {
+    Schema.lessThanDate(new Date(), { // Reverted to new Date()
       message: () => "Birth date must be in the past",
     }),
     Schema.annotations({
@@ -22,25 +23,59 @@ export class Cat extends Schema.Class<Cat>("Cat")({
       examples: [new Date("2022-01-01T00:00:00.000Z")],
     }),
   ),
-}) {
+  // Define an annotated Date, then make that schema optional.
+  deathDate: Schema.optional(
+    Schema.Date.pipe(
+      Schema.annotations({
+        description: "The date the cat died. If undefined, the cat is alive.",
+        examples: [new Date("2032-01-01T00:00:00.000Z")],
+      })
+    )
+  ),
+};
+
+const catStruct = Schema.Struct(catFields);
+
+// Use Schema.filter for schema-level validation
+const catSchemaFinal = pipe(
+  catStruct,
+  Schema.filter(
+    (cat: Schema.Schema.Type<typeof catStruct>) => cat.deathDate == null || cat.deathDate > cat.birthDate, // Check for null or undefined
+    { message: () => "Death date must be after birth date" }
+  )
+);
+
+export class Cat extends Schema.Class<Cat>("Cat")(catSchemaFinal) {
+  // Properties are now fully defined by catSchemaFinal via Schema.Class.
+  // Explicit declarations have been removed.
+  // `this` context in methods/getters will correctly refer to schema properties.
+
+  get isAlive(): boolean {
+    // `this.deathDate` is now correctly typed from the schema (Date | undefined)
+    return this.deathDate === undefined;
+  }
+
   getAgeAt(date: Date): number {
-    const today = date;
+    const effectiveDate = this.deathDate && date.getTime() > this.deathDate.getTime()
+      ? this.deathDate
+      : date;
+    // `this.birthDate` is now correctly typed from the schema (Date)
     const birthDate = this.birthDate;
 
-    if (today.getTime() < birthDate.getTime()) {
+    if (effectiveDate.getTime() < birthDate.getTime()) {
       return 0;
     }
 
-    let age = today.getUTCFullYear() - birthDate.getUTCFullYear();
-    const monthDiff = today.getUTCMonth() - birthDate.getUTCMonth();
+    let ageValue = effectiveDate.getUTCFullYear() - birthDate.getUTCFullYear();
+    const monthDiff = effectiveDate.getUTCMonth() - birthDate.getUTCMonth();
 
     if (
       monthDiff < 0 ||
-      (monthDiff === 0 && today.getUTCDate() < birthDate.getUTCDate())
+      (monthDiff === 0 && effectiveDate.getUTCDate() < birthDate.getUTCDate())
     ) {
-      age--;
+      ageValue--;
     }
-    return age;
+    return ageValue;
   }
 
   get age(): number {


### PR DESCRIPTION
- Introduces an optional `deathDate` to the `Cat` domain entity.
- Adds an `isAlive` getter to the `Cat` entity.
- Modifies `getAgeAt` and the `age` getter to correctly calculate age for deceased cats (age at time of death).
- Ensures `deathDate`, if set, must be after `birthDate` through schema validation using `Schema.filter`.
- Updates tests for the `Cat` entity to cover new functionality, including schema validations and age calculations for living and deceased cats.
- Verifies that repository, service, and API contract layers correctly adapt to the entity changes without modification due to their generic nature and reliance on the `Cat` schema.